### PR TITLE
build(deps-dev): update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 25
+    groups:
+      all-minor-patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       - dependency-name: "@angular*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
This setting merges minor and patch updates into groups for each pull request. This saves time when updating.