### PR TITLE
fix: headless chrome does not start

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -37,8 +37,18 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['ChromeHeadless'],
+    browsers: ['ChromiumHeadless'],
     singleRun: false,
-    restartOnFileChange: true
+    restartOnFileChange: true,
+    customLaunchers: {
+      ChromiumHeadless: {
+        base: 'Chromium',
+        flags: [
+          '--headless',
+          '--no-sandbox',
+          '--remote-debugging-port=0'
+        ]
+      }
+    }
   });
 };


### PR DESCRIPTION
I encountered Chromium D-Bus connection errors when running tests in Debian dev container, which prevented the test suite from executing properly.